### PR TITLE
docs(scalers): Update `cpu` and `memory` scaler docs for validating `requests`/`limits` from `LimitRange`

### DIFF
--- a/content/docs/2.13/scalers/cpu.md
+++ b/content/docs/2.13/scalers/cpu.md
@@ -13,7 +13,7 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include at least one of `requests` or `limits`.
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
 - The configuration for your Kubernetes Pods must include a `resources` section with specified `requests` (or `limits`). See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` (or `default` for limits) is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` (or `default` for limits) is missing too, the error `missing request for {cpu/memory}` occurs.

--- a/content/docs/2.13/scalers/cpu.md
+++ b/content/docs/2.13/scalers/cpu.md
@@ -16,7 +16,7 @@ go_file = "cpu_memory_scaler"
 KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` is missing too, the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests` (or `limits`). See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` (or `default` for limits) is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` (or `default` for limits) is missing too, the error `missing request for {cpu/memory}` occurs.
 
 ```yaml
 # a working example of resources with specified requests

--- a/content/docs/2.13/scalers/cpu.md
+++ b/content/docs/2.13/scalers/cpu.md
@@ -16,7 +16,7 @@ go_file = "cpu_memory_scaler"
 KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` is missing too, the error `missing request for {cpu/memory}` occurs.
 
 ```yaml
 # a working example of resources with specified requests

--- a/content/docs/2.13/scalers/memory.md
+++ b/content/docs/2.13/scalers/memory.md
@@ -16,7 +16,7 @@ go_file = "cpu_memory_scaler"
 KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` is missing too, the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests` (or `limits`). See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` (or `default` for limits) is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` (or `default` for limits) is missing too, the error `missing request for {cpu/memory}` occurs.
 
 ```yaml
 # a working example of resources with specified requests

--- a/content/docs/2.13/scalers/memory.md
+++ b/content/docs/2.13/scalers/memory.md
@@ -16,7 +16,7 @@ go_file = "cpu_memory_scaler"
 KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar), KEDA checks if the `defaultRequest` is set in `LimitRange` for the `Container` type in the same namespace. If `defaultRequest` is missing too, the error `missing request for {cpu/memory}` occurs.
 
 ```yaml
 # a working example of resources with specified requests


### PR DESCRIPTION
_Provide a description of what has been changed_

Update for cpu & memory scalers for KEDA controller checking for default limits and requests in LimitRange, for Container type, in the same namespace, for validation when the container resources are not specified in the pod spec.

Also, the following is updated:
When using `cpu` or `memory` scalers, the KEDA controller checks whether `requests` or `limits` are specified for the container resources. The `requests` are specified in the docs, but the `limits` are missing. This change updates the `cpu` and `memory` scaler docs to mention the `limits` that are also validated.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to issue kedacore/keda issues 5348
Relates to PR kedacore/keda pull 5377
